### PR TITLE
Allow greyscale images to be read

### DIFF
--- a/DGS/_dgs_class_web.py
+++ b/DGS/_dgs_class_web.py
@@ -215,8 +215,11 @@ def dgs(image, density=10, resolution=1, dofilter=1, maxscale=8, notes=8, verbos
    try:
        #im = imopen(image, flatten=1).astype('uint8')#.convert("L")
        #im = imread.imload(image, as_grey=True).astype('uint8')
-       im = imread(image)[:,:,:3] # read image up to 3 layers
-       im = np.squeeze(im) # squeeze singleton dimensions
+       im = imread(image)   # read the image straight with imread
+       im = np.squeeze(im)  # squeeze singleton dimensions
+       if len(np.shape(im))>3:
+           im = im[:, :, :3]            # only keep the first 3 bands
+       
        if len(np.shape(im))==3: # if rgb, convert to grey
           im = (0.299 * im[:,:,0] + 0.5870*im[:,:,1] + 0.114*im[:,:,2]).astype('uint8')
 


### PR DESCRIPTION
This unsolicited pull request allows greyscale images to be provided to the pyDGS. Previously, if there was only 1 band in the input image, the referencing to [ : , : , :3] would go out of bounds. No worries if this fix is out of scope for your project, thought I'd present it to you as I clean up on this project.

